### PR TITLE
Retain status code from subprocess

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,7 @@ fn main() -> ExitCode {
         .args(args)
         .status()
         .expect("Failed to execute the command!");
+    let code = status.code().expect("Process terminated by signal!");
 
-    match status.code() {
-        Some(0) => ExitCode::SUCCESS,
-        Some(code) => ExitCode::from(code as u8),
-        None => ExitCode::FAILURE,
-    }
+    ExitCode::from(code as u8)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,30 @@
 mod completions;
 
-use std::{env, io, process::Command};
+use std::{
+    env,
+    process::{Command, ExitCode},
+};
 
-fn main() -> io::Result<()> {
+fn main() -> ExitCode {
     let mut args = env::args().skip(1);
     let dir_or_flag = args.next().expect("Must provide a directory to run in!");
 
     if dir_or_flag == "--fish-completions" {
         println!("{}", completions::FISH);
-        return Ok(());
+        return ExitCode::SUCCESS;
     }
 
     let dir = dir_or_flag;
     let command = args.next().expect("Must provide a command to run!");
-    Command::new(command).current_dir(dir).args(args).status()?;
-    Ok(())
+    let status = Command::new(command)
+        .current_dir(dir)
+        .args(args)
+        .status()
+        .expect("Failed to execute the command!");
+
+    match status.code() {
+        Some(0) => ExitCode::SUCCESS,
+        Some(code) => ExitCode::from(code as u8),
+        None => ExitCode::FAILURE,
+    }
 }


### PR DESCRIPTION
Allows commands like the following to behave as expected.
Tested only on Linux.
```sh
$ doin ~ false || echo 1
```